### PR TITLE
Special-case handling of empty map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes to imgex
 
+## Pending changes
+
+* Support sending in an empty map as params
+
+Breaking Changes:
+* `Imgex.proxy_url/3` and `Imgex.url/3` no longer support params with value `nil`. Instead either don't pass the argument or pass in an empty map (`%{}`)
+
 ## v0.1.1
 * [#4: Extract path generation to remove Elixir 1.3 warning](https://github.com/ianwalter/imgex/issues/4)
 * [#5: Fix Elixir 1.4 missing parentheses warnings](https://github.com/ianwalter/imgex/issues/5)

--- a/test/imgex_test.exs
+++ b/test/imgex_test.exs
@@ -1,4 +1,14 @@
 defmodule ImgexTest do
   use ExUnit.Case
   doctest Imgex
+
+  test "proxy_url/2 when params are an empty map generates an appropriate url" do
+    assert Imgex.proxy_url("http://avatars.com/john-smith.png", %{}) ==
+      "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135"
+  end
+
+  test "url/2 when params are an empty map generates an appropriate url" do
+    assert Imgex.url("/images/jets.png", %{}) ==
+      "https://my-social-network.imgix.net/images/jets.png?s=7c6a3ef8679f4965f5aaecb66547fa61"
+  end
 end


### PR DESCRIPTION
Without this calling `Imgex.url(path, %{})` will result in an invalid url.