### PR TITLE
Support unsigned URLs

### DIFF
--- a/test/imgex_test.exs
+++ b/test/imgex_test.exs
@@ -12,6 +12,11 @@ defmodule ImgexTest do
              "https://my-social-network.imgix.net/images/jets.png?s=7c6a3ef8679f4965f5aaecb66547fa61"
   end
 
+  test "url/3 without token generates unsigned url" do
+    assert Imgex.url("/images/jets.png", %{}, %{token: nil}) ==
+             "https://my-social-network.imgix.net/images/jets.png"
+  end
+
   describe "srcset/3" do
     @default_srcset_widths ~w(
       100 116 134 156 182 210 244 282 328 380 442 512 594 688 798 926 1074


### PR DESCRIPTION
I use unsigned URLs to [purge images](https://docs.imgix.com/setup/purging-images) and as base URLs for clients to append their own parameters.

This pull request generates an unsigned URL when `source.token` is `nil`.

```elixir
Imgex.url(path, params, %{token: nil})
```

However, I’m not entirely happy with this solution but it‘s the best I can come up with to maintain backwards compatibility. The most idiomatic way would be to pass an option to a trailing `opts`.

```elixir
Imgex.url(path, params, sign: false)
```

Alternate source domains and tokens should be passed as `opts` too, but this is a breaking change.

What do you think?