### PR TITLE
docs: update README for imgix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
+<!-- ix-docs-ignore -->
 # imgex
 > Unofficial client library for generating imgix URLs in Elixir
 
 [![Hex version][hexImage]][hexUrl]
 [![CI][ciImage]][ciUrl]
+<!-- /ix-docs-ignore -->
+
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [Configuration](#configuration)
+- [Usage](#usage)
 
 ## Installation
 
@@ -32,21 +39,21 @@ the full package documentation is available at https://hexdocs.pm/imgex.
 
 ## Configuration
 
-To use the library you have to configure your Imgix domain and secure token or
+To use the library you have to configure your imgix domain and secure token or
 pass them as an options map `%{domain: "domain", token: "token"}` as the
 third parameter to `Imgex.url/3` or `Imgex.proxy_url/3`.
 See `config/test.exs` for an example of how to configure this.
 
 ## Usage
 
-To generate an Imgix url based on a path (Web Folder and S3 sources) and
+To generate an imgix url based on a path (Web Folder and S3 sources) and
 optional parameters do:
 
 ```elixir
 url = Imgex.url "/images/cats.jpg", %{w: 700}
 ```
 
-To generate an Imgix url based on a public URL (Web Proxy sources) and optional
+To generate an imgix url based on a public URL (Web Proxy sources) and optional
 parameters do:
 
 ```elixir


### PR DESCRIPTION
Hey @ianwalter! My name is Sherwin and I'm one of the SDK engineers at imgix 👋 

I wanted to start off by saying thank you for building and maintaining this project 😁 I'm especially happy to see that the library is up to date with some of our more recent SDK features, specifically srcset generation.

We are currently working on a project to update the [Libraries page](https://docs.imgix.com/libraries) on our Docs site, of which imgex is included as our recommended Elixir client library. Part of this project involves pulling README data directly from GitHub to display the detail page for each library, so we've been going through and [cleaning up the README files for our entire SDK](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aclosed+is%3Apr+user%3Aimgix+is%3Apublic+%22docs%3A%22+readme+author%3Asherwinski+sort%3Aupdated-desc). The new detail page design looks like this:

![sdk_docs_page](https://user-images.githubusercontent.com/15919091/72939501-d7164f00-3d21-11ea-9d49-1f11a7d69adb.png)

This PR proposes some of those same changes, which will ensure that the detail view for this project matches that of the other imgix SDK pages:
- Replacing any instances of "Imgix" with "imgix" to match the official spelling of the product.
- Wrapping the top section in `<!-- ix-docs-ignore -->` tags. These get ignored by GitHub, but the content inside this wrapper will be stripped out when we include the content in our own docs. This essentially lets us avoid including the same information (project name, description, sometimes build badges) twice at the top of every page.
- Adding a table of contents for some extra organization.

Again, thanks for maintaining this library and hope to get your thoughts on this!