### PR TITLE
Switch to using keyword lists internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to imgex
 
+## Unreleased
+
+* [#15 Fix compilation warnings and update deps](https://github.com/ianwalter/imgex/pull/15)
+* [#17 Switch to using keyword lists internally](https://github.com/ianwalter/imgex/pull/17)
+
 ## v0.3.0
 
 * [#8 Add Imgex.srcset to generate srcset pairs](https://github.com/ianwalter/imgex/pull/8)

--- a/test/imgex_test.exs
+++ b/test/imgex_test.exs
@@ -12,6 +12,13 @@ defmodule ImgexTest do
              "https://my-social-network.imgix.net/images/jets.png?s=7c6a3ef8679f4965f5aaecb66547fa61"
   end
 
+  test "url/2 supports a map params are an empty map generates an appropriate url" do
+    url = Imgex.url("/images/jets.png", %{fm: "auto", h: 100})
+    uri = URI.new!(url)
+
+    assert %{"fm" => "auto", "h" => "100"} = URI.decode_query(uri.query)
+  end
+
   describe "srcset/3" do
     @default_srcset_widths ~w(
       100 116 134 156 182 210 244 282 328 380 442 512 594 688 798 926 1074
@@ -35,7 +42,7 @@ defmodule ImgexTest do
     test "with only a height, generates 31 width pairs" do
       path = "/images/lulu.jpg"
 
-      srcset = Imgex.srcset(path, %{h: 100})
+      srcset = Imgex.srcset(path, h: 100)
       split = String.split(srcset, ",\n")
       assert length(split) == 31
 
@@ -43,7 +50,7 @@ defmodule ImgexTest do
       |> Enum.with_index()
       |> Enum.each(fn {width, i} ->
         src = Enum.at(split, i)
-        assert src == "#{Imgex.url(path, %{h: 100, w: width})} #{width}w"
+        assert src == "#{Imgex.url(path, w: width, h: 100)} #{width}w"
       end)
     end
 
@@ -56,13 +63,13 @@ defmodule ImgexTest do
       [1, 2, 3, 4, 5]
       |> Enum.each(fn dpr ->
         src = Enum.at(split, dpr - 1)
-        assert src == "#{Imgex.url(path, %{ar: "3:4", dpr: dpr, h: 100})} #{dpr}x"
+        assert src == "#{Imgex.url(path, dpr: dpr, h: 100, ar: "3:4")} #{dpr}x"
       end)
     end
 
     test "with a height, aspect ratio, and other params, generates 5 dpr pairs" do
       path = "/images/lulu.jpg"
-      params = %{ar: "3:4", crop: "faces,entropy,left", h: 100}
+      params = [ar: "3:4", crop: "faces,entropy,left", h: 100]
       srcset = Imgex.srcset(path, params)
       split = String.split(srcset, ",\n")
       assert length(split) == 5
@@ -70,7 +77,7 @@ defmodule ImgexTest do
       [1, 2, 3, 4, 5]
       |> Enum.each(fn dpr ->
         src = Enum.at(split, dpr - 1)
-        assert src == "#{Imgex.url(path, Map.put(params, :dpr, dpr))} #{dpr}x"
+        assert src == "#{Imgex.url(path, Keyword.put(params, :dpr, dpr))} #{dpr}x"
       end)
     end
 
@@ -83,7 +90,7 @@ defmodule ImgexTest do
       [1, 2, 3, 4, 5]
       |> Enum.each(fn dpr ->
         src = Enum.at(split, dpr - 1)
-        assert src == "#{Imgex.url(path, %{dpr: dpr, w: 100})} #{dpr}x"
+        assert src == "#{Imgex.url(path, dpr: dpr, w: 100)} #{dpr}x"
       end)
     end
   end


### PR DESCRIPTION
This allows the tests to be more reliable because they're asserting against the order of query parameters, and maps are not ordered in Elixir which was causing the tests to not be reliable (especially on more recent Erlang installations).